### PR TITLE
Resolved Issue #32

### DIFF
--- a/Nasal/data.nas
+++ b/Nasal/data.nas
@@ -108,7 +108,7 @@ var select = func (bay, rack) {
             }
             wp.setContacts([spot]);
             # Temporarily
-            # TODO: Figure out why this is needed
+            # .start() is called so that in .standby, .startup() is called and can call search() to lock onto armament.contactPoint
             wp.start();
         }
     }


### PR DESCRIPTION
- `.start()` sets `me.ready_standby_time` to current time.
  `me.ready_standby_time`  is the time the weapon was started.
- `.start()` sets `me.status` to `MISSILE_STARTING`
- `.standby()` calls `.startup()` if `me.status == MISSILE_STARTING`
- In order for `.search()` to be called in `.startup()`: 
 `me.curr_time = getprop("sim/time/elapsed-sec");`
 `me.curr_time > (me.ready_standby_time + me.ready_time)`
- `me.ready_time` is the amount of time before you can do anything with the weapon
- `.search()` tries to lock onto `contact`
<br>


`.start()` must be called in `weapon.select` so that `.search()` can lock onto `armament.contactPoint`
